### PR TITLE
Button Component (primary & secondary) & some config file additions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
     "module": false,
     "Promise": false,
     "__dirname": true,
+    "global": true,
   },
   "env": {
     "jest": true

--- a/jest-preprocess.js
+++ b/jest-preprocess.js
@@ -1,0 +1,4 @@
+const babelOptions = {
+  presets: ["babel-preset-gatsby"],
+}
+module.exports = require("babel-jest").createTransformer(babelOptions)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  transform: {
+    "^.+\\.jsx?$": `<rootDir>/jest-preprocess.js`,
+  },
+  moduleNameMapper: {
+    ".+\\.(css|styl|less|sass|scss)$": `identity-obj-proxy`,
+    ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": `<rootDir>/__mocks__/file-mock.js`,
+  },
+  testPathIgnorePatterns: [`node_modules`, `.cache`, `public`],
+  transformIgnorePatterns: [`node_modules/(?!(gatsby)/)`],
+  globals: {
+    __PATH_PREFIX__: ``,
+  },
+  testURL: `http://localhost`,
+  setupFiles: [`<rootDir>/loadershim.js`],
+  coverageDirectory: "./coverage/",
+  collectCoverage: true,
+}

--- a/loadershim.js
+++ b/loadershim.js
@@ -1,0 +1,3 @@
+global.___loader = {
+  enqueue: jest.fn(),
+}

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -1,0 +1,46 @@
+import React from "react"
+import PropTypes from "prop-types"
+import styled from "styled-components"
+import "typeface-montserrat"
+
+const ButtonContainer = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #3c7bba;
+  border: 2px solid #3c7bba;
+  border-radius: 14px;
+  color: white;
+
+  font-family: "Montserrat", sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 1.3em;
+  width: 19rem;
+  padding: 13px 0;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.6);
+  outline: none;
+  cursor: pointer;
+
+  ${({ secondary }) => secondary && "background-color: white;"}
+  ${({ secondary }) => secondary && "color: #3C7BBA;"}
+`
+
+const Button = ({ secondary, children, ...props }) => {
+  return (
+    <ButtonContainer {...props} secondary={secondary}>
+      {children}
+    </ButtonContainer>
+  )
+}
+
+Button.propTypes = {
+  secondary: PropTypes.bool.isRequired,
+  children: PropTypes.string.isRequired,
+}
+
+Button.defaultProps = {
+  secondary: false,
+}
+
+export default Button


### PR DESCRIPTION
Added a reusable component as a button. It functions the same way a regular `Button` html tag functions and takes all the same props, like onClick, name, etc. However, by default the styling is automatically styled to the primary blue in Figma, whereas if you pass the flag prop `secondary`, you'll get the secondary look of the button as seen on the homepage on Figma.